### PR TITLE
fix: fix visual studio default build type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ Thumbs.db
 # Build results
 Debug/
 Release/
+cmake-build-debug/
+cmake-build-release/
 
 # Libraries
 /projects/Open-Rival/libs/

--- a/CMake/StandardProjectSettings.cmake
+++ b/CMake/StandardProjectSettings.cmake
@@ -32,3 +32,8 @@ if(ENABLE_IPO)
         message(SEND_ERROR "IPO is not supported: ${output}")
     endif()
 endif()
+
+if (MSVC)
+    set(CMAKE_GENERATOR_PLATFORM "Win32" CACHE STRING "" FORCE)
+endif()
+

--- a/create_vs_solution.bat
+++ b/create_vs_solution.bat
@@ -1,0 +1,19 @@
+@echo off
+
+REM Set the build type based on the command-line argument
+set "BUILD_TYPE=%~1"
+if "%BUILD_TYPE%"=="" set "BUILD_TYPE=debug"
+if /I "%BUILD_TYPE%" neq "debug" if /I "%BUILD_TYPE%" neq "release" set "BUILD_TYPE=debug"
+
+set "SOURCE_DIR=%~dp0"
+set "BUILD_DIR=%SOURCE_DIR%\cmake-build-%BUILD_TYPE%"
+
+REM Create the build directory
+mkdir "%BUILD_DIR%"
+
+REM Change to the build directory
+cd /D "%BUILD_DIR%"
+
+REM Configure the CMake project
+cmake  -A Win32 ..
+cd ..


### PR DESCRIPTION
includes a bat script to create the visual studio solution to only be Win32 as cmake-gui does not seem to properly set the variables to only build for Win32